### PR TITLE
:bug: animate compatible with Firefox

### DIFF
--- a/lib/components/borderBox1/src/main.vue
+++ b/lib/components/borderBox1/src/main.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="dv-border-box-1">
-    <svg
-      width="150px"
-      height="150px"
-      :key="item"
-      v-for="item in border"
-      :class="`${item} border`"
-    >
+    <svg width="150px" height="150px" :key="item" v-for="item in border" :class="`${item} border`">
       <polygon
         fill="#4fd2dd"
         points="6,66 6,18 12,12 18,12 24,6 27,6 30,9 36,9 39,6 84,6 81,9 75,9 73.2,7 40.8,7 37.8,10.2 24,10.2 12,21 12,24 9,27 9,51 7.8,54 7.8,63"
@@ -14,7 +8,7 @@
         <animate
           attributeName="fill"
           values="#4fd2dd;#235fa7;#4fd2dd"
-          dur=".5s"
+          dur="0.5s"
           begin="0s"
           repeatCount="indefinite"
         />
@@ -26,7 +20,7 @@
         <animate
           attributeName="fill"
           values="#235fa7;#4fd2dd;#235fa7"
-          dur=".5s"
+          dur="0.5s"
           begin="0s"
           repeatCount="indefinite"
         />
@@ -37,7 +31,7 @@
       >
         <animate
           attributeName="fill"
-          values="#4fd2dd;#235fa7;#transparent"
+          values="#4fd2dd;#235fa7;transparent"
           dur="1s"
           begin="0s"
           repeatCount="indefinite"

--- a/src/components/borderBox1/src/main.vue
+++ b/src/components/borderBox1/src/main.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="dv-border-box-1">
-    <svg
-      width="150px"
-      height="150px"
-      :key="item"
-      v-for="item in border"
-      :class="`${item} border`"
-    >
+    <svg width="150px" height="150px" :key="item" v-for="item in border" :class="`${item} border`">
       <polygon
         fill="#4fd2dd"
         points="6,66 6,18 12,12 18,12 24,6 27,6 30,9 36,9 39,6 84,6 81,9 75,9 73.2,7 40.8,7 37.8,10.2 24,10.2 12,21 12,24 9,27 9,51 7.8,54 7.8,63"
@@ -14,7 +8,7 @@
         <animate
           attributeName="fill"
           values="#4fd2dd;#235fa7;#4fd2dd"
-          dur=".5s"
+          dur="0.5s"
           begin="0s"
           repeatCount="indefinite"
         />
@@ -26,7 +20,7 @@
         <animate
           attributeName="fill"
           values="#235fa7;#4fd2dd;#235fa7"
-          dur=".5s"
+          dur="0.5s"
           begin="0s"
           repeatCount="indefinite"
         />
@@ -37,7 +31,7 @@
       >
         <animate
           attributeName="fill"
-          values="#4fd2dd;#235fa7;#transparent"
+          values="#4fd2dd;#235fa7;transparent"
           dur="1s"
           begin="0s"
           repeatCount="indefinite"


### PR DESCRIPTION
.5s 与 #transparent 写法，chrome 会尝试理解，但火狐不会尝试去理解或理解出了偏差，导致动画失效